### PR TITLE
Update Willow parameter in forest_and_mano_usage.ipynb script

### DIFF
--- a/code/forest_mano/forest_and_mano_usage.ipynb
+++ b/code/forest_mano/forest_and_mano_usage.ipynb
@@ -355,7 +355,7 @@
     "\n",
     "\n",
     "forest.willow.log_stats.log_stats_main(\n",
-    "    data_dir, comm_output_dir, tz_str, option, beiwe_id = beiwe_ids\n",
+    "    data_dir, comm_output_dir, tz_str, option, beiwe_ids = beiwe_ids\n",
     ")"
    ]
   },


### PR DESCRIPTION
The [Beiwe taskrunner (#228)](https://github.com/onnela-lab/forest/commit/6355d5188fe3f7251b874c0645fce383b18b78e0) commit changed the name of one Willow parameter from "beiwe_id" to "beiwe_ids". This pull request amends the parameter names in the willow call in the forest_and_mano_usage.ipynb script.