### PR TITLE
Enable PCR in Jasmine's default call

### DIFF
--- a/code/forest_mano/forest_and_mano_usage.ipynb
+++ b/code/forest_mano/forest_and_mano_usage.ipynb
@@ -85,8 +85,9 @@
    "outputs": [],
    "source": [
     "#run this chunk to install mano and forest\n",
-    "!pip install mano \n",
-    "!pip install --upgrade https://github.com/onnela-lab/forest/tarball/develop"
+    "%pip install mano \n",
+    "%pip install --upgrade https://github.com/onnela-lab/forest/tarball/develop\n",
+    "%pip install orjson"
    ]
   },
   {
@@ -274,7 +275,10 @@
     "# by setting parameters = None or not passing in the parameters argument\n",
     "parameters = Hyperparameters()\n",
     "parameters.save_osm_log = False\n",
-    "parameters.log_threshold = 60\n",
+    "parameters.log_threshold = 60 # threshold, in minutes, for logging locations if OSM analysis is enabled\n",
+    "parameters.pcr_bool = True # enables physical circadian rhythm (PCR) statistics\n",
+    "parameters.pcr_window = 14 # number of days to look back and forward for calculating PCR\n",
+    "parameters.pcr_sample_rate = 30 # sample rate in seconds\n",
     "\n",
     "gps_stats_main(\n",
     "    data_dir, gps_output_dir, tz_str, freq, save_traj, places_of_interest = places_of_interest, \n",
@@ -600,9 +604,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
There are three main changes encased within this commit:
1. Enabling physical circadian rhythm analysis in `forest_and_mano_usage.ipynb` using the default settings as specified in the [wiki](https://forest.beiwe.org/en/latest/jasmine.html#:~:text=(28)%20pcr_window%3A%20int%2C%20number%20of%20days%20to%20look%20back%20and%20forward%20for%20calculating%20the%20physical%20cyrcadian%20rhythm%20(default%3A%2014)%0A(29)%20pcr_sample_rate%3A%20int%2C%20number%20of%20seconds%20between%20each%20sample%20for%20calculating%20the%20physical%20cyrcadian%20rhythm%20(default%3A%2030)).
2. Changing `!pip install` to `%pip install` to ensure that packages are installed to the current virtual environment
3. Adding a `pip install orjson` statement