### PR TITLE
Data download timezone

### DIFF
--- a/code/forest_mano/forest_and_mano_usage.ipynb
+++ b/code/forest_mano/forest_and_mano_usage.ipynb
@@ -132,6 +132,7 @@
     "- For **server**, enter the server where data is located. If your Beiwe website URL starts with studies.beiwe.org, enter \"studies\"\n",
     "- For **time_start**, enter the earliest date you want to download data for, in YYYY-MM-DD format.\n",
     "- For **time_end**, enter the latest date you want to download data for, in YYYY-MM-DD format. If this is None, mano will download all data available (up until today at midnight). \n",
+    "- For **tz_str**, enter the time zone where the study was conducted. Here, it's **\"America/New_York.\"** We can use \"pytz.all_timezones\" to check all options.\n",
     "- For **data_streams**, enter a list of data streams you want to download. Forest currently analyzes `gps`, `survey_timings`, `calls`, and `texts` data streams. A full list of data types can be found under the \"Download Data\" tab of the Beiwe website. If this is None, all possible data streams will be downloaded. \n",
     "- For **beiwe_ids**, enter a list of Beiwe IDs you want to download data for. If you leave this as an empty list, mano will attempt to download data for all user IDs"
    ]
@@ -149,6 +150,7 @@
     "server = \"studies\"\n",
     "time_start = \"2008-01-01\"\n",
     "time_end = None\n",
+    "tz_str = \"America/New_York\"\n",
     "data_streams = [\"gps\", \"survey_timings\", \"survey_answers\", \"audio_recordings\", \"calls\", \"texts\", \"accelerometer\"]\n",
     "beiwe_ids = []\n",
     "\n",
@@ -195,7 +197,7 @@
     "import os\n",
     "\n",
     "from helper_functions import download_data\n",
-    "download_data(kr, study_id, dest_dir, beiwe_ids, time_start, time_end, data_streams)"
+    "download_data(kr, study_id, dest_dir, tz_str, beiwe_ids, time_start, time_end, data_streams)"
    ]
   },
   {

--- a/code/forest_mano/helper_functions.py
+++ b/code/forest_mano/helper_functions.py
@@ -155,8 +155,6 @@ def download_data(keyring, study_id, download_folder, tz_str, users = [], time_s
         print("Error: Timezone is blank")
         return
 
-    local_timezone = pytz.timezone(tz_str)
-
     if time_end is None:
         time_end = datetime.today().strftime("%Y-%m-%d")+"T23:59:00"
     else:


### PR DESCRIPTION
 - Previously, download_data function would download the data in UTC. Ex. from 1/01 to 1/07 would mean 1/01 00:00:00 UTC to 1/07 23:59:00 UTC. However, the server would download the data based on the study's timezone. Ex. from 1/01 to 1/07 would mean 1/01 00:00:00 EST to 1/07 23:59:00 EST assuming the study's timezone is EST
 - This adds a tz_str field to the download_data function - allowing users to specify the study timezone, then converts the date to UTC then attempts data download.